### PR TITLE
Disable UART before resetting

### DIFF
--- a/src/boards.c
+++ b/src/boards.c
@@ -149,6 +149,9 @@ void board_teardown(void)
 
   // Stop LF clock
   NRF_CLOCK->TASKS_LFCLKSTOP = 1UL;
+
+  // Stop UART0
+  NRF_UART0->ENABLE = 0;
 }
 
 static uint32_t _systick_count = 0;


### PR DESCRIPTION
The UART causes 1.25mA current consumption in sleep mode when left enabled. That's a massive power drain! While the application could disable the UART, it seems better to fix this directly in the bootloader.